### PR TITLE
fix: reset consumed request stream when debug logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,5 +140,7 @@ docker/artifacts/EEMVke69ZjQAXoK3FTLtCwpyWOXx5qkhzIDqXAgYfPgh/keri.cesr
 .DS_Store
 keri.cesr
 
-tests/artifact_output_dir/**/**.json
+tests/artifact_output_dir/**/*.json
 tests/artifact_output_dir/**/*.cesr
+tests/artifact_output_dir/dws/*
+tests/artifact_output_dir/dws/**/*

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 	build-dynamic-service publish-dynamic-service tag-dynamic-service-latest \
 	build-did-webs-resolver-service publish-did-webs-resolver-service tag-did-webs-resolver-latest \
 	run-agent build-all publish-latest warn tag fmt check tag-latest-all
-VERSION=0.3.0
+VERSION=0.3.1  # also change in pyproject.toml and src/dws/__init__.py
 
 RED="\033[0;31m"
 NO_COLOUR="\033[0m"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dws"
-version = "0.3.0" # also change in src/dws/__init__.py
+version = "0.3.1" # also change in src/dws/__init__.py and Makefile
 description = "did:webs DID Method Resolver"
 readme = "README.md"
 requires-python = "==3.12.6"

--- a/src/dws/__init__.py
+++ b/src/dws/__init__.py
@@ -1,3 +1,5 @@
+__version__ = '0.3.1'  # also change in pyproject.toml and Makefile
+
 # Logging config
 import logging
 
@@ -38,7 +40,3 @@ class UnknownAID(DidWebsError):
     def __init__(self, aid: str, did: str):
         super().__init__(f'Unknown AID {aid} found in {did}')
         self.aid = aid
-
-
-# Versioning
-__version__ = '0.3.0'  # also change in pyproject.toml

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -197,7 +197,8 @@ class HabbingHelpers:
             salt(bytes): passed to habitat to use for inception raw salt not qb64
             temp(bool): indicates if this uses temporary databases
             cf(Configer): optional configer for loading configuration data
-
+        TODO: replace this openHab fixture with one from KERIpy once https://github.com/WebOfTrust/keripy/pull/1078 is merged.
+              this copy was needed in order to pass cf to Habery.makeHab() since the **kwa is not unpacking the cf arg.
         """
 
         salt = core.Salter(raw=salt).qb64

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ https://docs.pytest.org/en/latest/pythonpath.html
 
 import json
 from contextlib import contextmanager
+from pathlib import Path
 from typing import List, Union
 
 import pytest
@@ -251,9 +252,18 @@ def self_attested_aliases_cred_subj(domain: str, aid: str, port: str = None, pat
     )
 
 
-def load_designated_aliases_schema_json():
-    return json.loads(open('./local/schema/designated-aliases-public-schema.json', 'rb').read())
+class Schema:
+    """
+    Using pathlib to load schema and rules files from "tests/schema" using the relative .parent path
+    allows tests to be run from any working directory.
+    """
 
+    @staticmethod
+    def designated_aliases_schema():
+        schema_path = Path(__file__).parent / 'schema' / 'designated-aliases-public-schema.json'
+        return json.loads(schema_path.read_bytes())
 
-def load_designated_aliases_schema_rules_json():
-    return json.loads(open('./local/schema/rules/desig-aliases-public-schema-rules.json', 'rb').read())
+    @staticmethod
+    def designated_aliases_rules():
+        schema_path = Path(__file__).parent / 'schema' / 'rules' / 'desig-aliases-public-schema-rules.json'
+        return json.loads(schema_path.read_bytes())

--- a/tests/dws/core/test_generating.py
+++ b/tests/dws/core/test_generating.py
@@ -1,7 +1,11 @@
+import io
 import json
+import logging
 import os
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
+import falcon
+import pytest
 from hio.base import doing
 from keri import core
 from keri.app import configing, habbing, oobiing
@@ -10,6 +14,7 @@ from mockito import mock
 
 from dws.core import artifacting, didding, generating, resolving
 from dws.core.ends import DID_JSON, KERI_CESR
+from dws.core.resolving import RequestLoggerMiddleware
 from tests import conftest
 from tests.conftest import CredentialHelpers, HabbingHelpers, WitnessContext, self_attested_aliases_cred_subj
 
@@ -157,3 +162,40 @@ def test_did_art_genr_with_empty_hby_creates_hby():
         )
         assert resolver.hby == hby_mock, 'Expected KeriResolver to create a new Habery instance'
         assert hby_doer_mock in resolver.doers, 'Expected KeriResolver to add HaberyDoer to its doers'
+
+
+@pytest.fixture
+def mock_req():
+    req = Mock(spec=falcon.Request)
+    req.method = 'POST'
+    req.url = '/test'
+    req.headers = {'Content-Type': 'application/json'}
+    req.content_length = 10
+    req.stream = io.BytesIO(b'{"key": "value"}')  # Mock stream for body read
+    req.env = {'wsgi.input': req.stream, 'CONTENT_LENGTH': '10'}
+    return req
+
+
+@pytest.fixture
+def mock_resp():
+    return Mock(spec=falcon.Response)
+
+
+def test_request_logger_middleware_on_debug(mock_req, mock_resp):
+    """
+    Test that the request logger middleware logs requests when debug is enabled.
+    """
+    middleware = RequestLoggerMiddleware()
+
+    with (
+        patch('dws.core.resolving.logger.isEnabledFor') as mock_enabled,
+        patch('dws.core.resolving.logger.debug') as mock_debug,
+    ):
+        mock_enabled.return_value = True  # Force enabled path
+
+        middleware.process_request(mock_req, mock_resp)
+
+        mock_enabled.assert_called_with(logging.DEBUG)
+        mock_debug.assert_called_with('Request body    : %s', '{"key": "value"}')  # Or '<empty>' if no body
+        assert mock_req.env['wsgi.input'].read() == b'{"key": "value"}'  # Reset worked
+        assert mock_req.env['CONTENT_LENGTH'] == '16'  # Updated to actual len

--- a/tests/dws/core/test_generating.py
+++ b/tests/dws/core/test_generating.py
@@ -82,8 +82,8 @@ def test_artifact_generation_creates_expected_artifacts():
 
         # Expects the test to be run from the root of the repository
         regery = credentialing.Regery(hby=rb_hby, name=rb_hby.name, temp=rb_hby.temp)
-        schema_json = conftest.load_designated_aliases_schema_json()
-        rules_json = conftest.load_designated_aliases_schema_rules_json()
+        schema_json = conftest.Schema.designated_aliases_schema()
+        rules_json = conftest.Schema.designated_aliases_rules()
         subject_data = self_attested_aliases_cred_subj(host, aid, port, did_path)
         CredentialHelpers.add_cred_to_aid(
             hby=rb_hby,

--- a/tests/dws/core/test_resolving.py
+++ b/tests/dws/core/test_resolving.py
@@ -17,7 +17,7 @@ from keri.db.basing import dbdict
 from keri.vdr import credentialing, verifying
 from mockito import mock, when
 
-from dws import ArtifactResolveError
+from dws import ArtifactResolveError, log_name, ogler, set_log_level
 from dws.core import artifacting, didding, generating, requesting, resolving
 from dws.core.didkeri import KeriResolver
 from dws.core.ends import monitoring
@@ -43,6 +43,10 @@ def test_resolver_with_witnesses():
     This test spins up an actual witness and performs proper, receipted inception and credential
     issuance for an end-to-end integration test of the universal resolver endpoints.
     """
+    # setting log level to DEBUG so that it triggers the debug logging branch in the RequestLoggerMiddleware
+    logger = ogler.getLogger(log_name)
+    set_log_level('DEBUG', logger)
+
     aid_salt = b'0AAB_Fidf5WeZf6VFc53IxVw'
     resolver_salt = b'0AAl3nvsqKGyKHp2Hz9wLy9t'
     registry_nonce = '0ADV24br-aaezyRTB-oUsZJE'
@@ -296,6 +300,8 @@ def test_resolver_with_witnesses():
             assert 'resolution timed out' in keri_resolver.result['error'], (
                 'KeriResolver result did not contain expected timeout error'
             )
+    # reset log level for other tests
+    set_log_level('INFO', logger)
 
 
 def test_artifact_server_hosts_artifacts():

--- a/tests/dws/core/test_resolving.py
+++ b/tests/dws/core/test_resolving.py
@@ -130,8 +130,8 @@ def test_resolver_with_witnesses():
         keri_cesr_url = f'http://{host}:{port}/{did_path}/{aid}/keri.cesr'            # http://127.0.0.1:7677/dws/EEdpe-yqftH2_FO1-luoHvaiShK4y_E2dInrRQ2_2X5v/keri.cesr
         # fmt: on
 
-        schema_json = conftest.load_designated_aliases_schema_json()
-        rules_json = conftest.load_designated_aliases_schema_rules_json()
+        schema_json = conftest.Schema.designated_aliases_schema()
+        rules_json = conftest.Schema.designated_aliases_rules()
         subject_data = self_attested_aliases_cred_subj(host, aid, port, did_path)
         regery = credentialing.Regery(hby=ck_hby, name=ck_hby.name, temp=ck_hby.temp)
         CredentialHelpers.add_cred_to_aid(
@@ -587,7 +587,7 @@ def test_resolver_with_did_webs_did_returns_correct_doc():
         deeds = doist.enter(doers=[hby_doer, counselor, registrar, credentialer, regery_doer])
 
         # Add schema to resolver schema cache
-        raw_schema = conftest.load_designated_aliases_schema_json()
+        raw_schema = conftest.Schema.designated_aliases_schema()
         schemer = scheming.Schemer(
             raw=bytes(json.dumps(raw_schema), 'utf-8'), typ=scheming.JSONSchema(), code=coring.MtrDex.Blake3_256
         )
@@ -609,7 +609,7 @@ def test_resolver_with_did_webs_did_returns_correct_doc():
 
         # Create and issue the self-attested credential
         credSubject = self_attested_aliases_cred_subj(host, aid, port, did_path)
-        rules_json = conftest.load_designated_aliases_schema_rules_json()
+        rules_json = conftest.Schema.designated_aliases_rules()
         creder = credentialer.create(
             regname=issuer_reg.name,
             recp=None,
@@ -841,8 +841,8 @@ def test_resolver_with_metadata_returns_correct_doc():
         # fmt: on
 
         regery = credentialing.Regery(hby=hby, name=hab.name, temp=hby.temp)
-        schema_json = conftest.load_designated_aliases_schema_json()
-        rules_json = conftest.load_designated_aliases_schema_rules_json()
+        schema_json = conftest.Schema.designated_aliases_schema()
+        rules_json = conftest.Schema.designated_aliases_rules()
         subject_data = self_attested_aliases_cred_subj(host, aid, port, did_path)
         CredentialHelpers.add_cred_to_aid(
             hby=hby,

--- a/tests/schema/designated-aliases-public-schema.json
+++ b/tests/schema/designated-aliases-public-schema.json
@@ -1,0 +1,156 @@
+{
+    "$id": "EN6Oh5XSD5_q2Hgu-aqpdfbVepdpYpFlgz6zvJL5b_r5",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Designated Aliases Public Attestation",
+    "description": "A public attestation listing the designated aliases of an AID controller.",
+    "type": "object",
+    "credentialType": "DesignatedAliasesPublicAttestation",
+    "version": "1.0.0",
+    "properties": {
+        "v": {
+            "description": "Version",
+            "type": "string"
+        },
+        "d": {
+            "description": "Attestation SAID",
+            "type": "string"
+        },
+        "i": {
+            "description": "Controller AID",
+            "type": "string"
+        },
+        "ri": {
+            "description": "Attestation status registry",
+            "type": "string"
+        },
+        "s": {
+            "description": "schema section",
+            "oneOf": [
+                {
+                    "description": "schema section SAID",
+                    "type": "string"
+                },
+                {
+                    "description": "schema detail",
+                    "type": "object"
+                }
+            ]
+        },
+        "a": {
+            "oneOf": [
+                {
+                    "description": "Attributes block SAID",
+                    "type": "string"
+                },
+                {
+                    "$id": "EBMVc1eOhOaA7MdwAlAX3KcvJRTpFrc7_xcB_XveYAEE",
+                    "description": "Attributes block",
+                    "type": "object",
+                    "properties": {
+                        "d": {
+                            "description": "Attributes block SAID",
+                            "type": "string"
+                        },
+                        "dt": {
+                            "description": "Designation date time",
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "ids": {
+                            "description": "List of namespaced/controlled AID aliases designated by the AID controller",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "d",
+                        "dt",
+                        "ids"
+                    ]
+                }
+            ]
+        },
+        "r": {
+            "oneOf": [
+                {
+                    "description": "Rules block SAID",
+                    "type": "string"
+                },
+                {
+                    "$id": "EHbxC6vD0mU49geUxIfcQtTxP2tAqay7QCz3CVzfSdHz",
+                    "description": "Rules block",
+                    "type": "object",
+                    "properties": {
+                        "d": {
+                            "description": "Rules block SAID",
+                            "type": "string"
+                        },
+                        "aliasDesignation": {
+                            "description": "Alias designation",
+                            "type": "object",
+                            "properties": {
+                                "l": {
+                                    "type": "string",
+                                    "const": "The issuer of this ACDC designates the identifiers in the ids field as the only allowed namespaced aliases of the issuer's AID."
+                                }
+                            }
+                        },
+                        "usageDisclaimer": {
+                            "description": "Usage Disclaimer",
+                            "type": "object",
+                            "properties": {
+                                "l": {
+                                    "description": "Limitation of designation scope",
+                                    "type": "string",
+                                    "const": "This attestation only asserts designated aliases of the controller of the AID, that the AID controlled namespaced alias has been designated by the controller. It does not assert that the controller of this AID has control over the infrastructure or anything else related to the namespace other than the included AID."
+                                }
+                            }
+                        },
+                        "issuanceDisclaimer": {
+                            "description": "Issuance Disclaimer",
+                            "type": "object",
+                            "properties": {
+                                "l": {
+                                    "description": "Accuracy of information",
+                                    "type": "string",
+                                    "const": "All information in a valid and non-revoked alias designation assertion is accurate as of the date specified."
+                                }
+                            }
+                        },
+                        "termsOfUse": {
+                            "description": "Terms of use",
+                            "type": "object",
+                            "properties": {
+                                "l": {
+                                    "type": "string",
+                                    "const": "Designated aliases of the AID must only be used in a manner consistent with the expressed intent of the AID controller."
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "d",
+                        "aliasDesignation",
+                        "usageDisclaimer",
+                        "issuanceDisclaimer",
+                        "termsOfUse"
+                    ]
+                }
+            ]
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "v",
+        "d",
+        "i",
+        "ri",
+        "s",
+        "a",
+        "r"
+    ]
+}

--- a/tests/schema/rules/desig-aliases-public-schema-rules.json
+++ b/tests/schema/rules/desig-aliases-public-schema-rules.json
@@ -1,0 +1,15 @@
+{
+  "d": "EEVTx0jLLZDQq8a5bXrXgVP0JDP7j8iDym9Avfo8luLw",
+  "aliasDesignation": {
+    "l": "The issuer of this ACDC designates the identifiers in the ids field as the only allowed namespaced aliases of the issuer's AID."
+  },
+  "usageDisclaimer": {
+    "l": "This attestation only asserts designated aliases of the controller of the AID, that the AID controlled namespaced alias has been designated by the controller. It does not assert that the controller of this AID has control over the infrastructure or anything else related to the namespace other than the included AID."
+  },
+  "issuanceDisclaimer": {
+    "l": "All information in a valid and non-revoked alias designation assertion is accurate as of the date specified."
+  },
+  "termsOfUse": {
+    "l": "Designated aliases of the AID must only be used in a manner consistent with the expressed intent of the AID controller."
+  }
+}

--- a/uv.lock
+++ b/uv.lock
@@ -178,7 +178,7 @@ wheels = [
 
 [[package]]
 name = "dws"
-version = "0.2.7"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "falcon" },


### PR DESCRIPTION
The prior version of the RequestLoggerMiddleware would consume the request body stream with req.stream.read() which broke HTTP POST requests (currently unused by the did:webs resolver) because the stream is a one-shot IO read meaning that the stream must be reset in order to be later consumed by the Falcon HTTP request handler. The logging was also updated to use placeholders rather than f-strings for performance.