### PR TITLE
Delegation service support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,56 @@
+# Changelog for did:webs resolver
+
+## Version History
+
+### Versions prior to 0.3.0 (hyperledger-labs/did-webs-resolver history)
+
+### 0.3.2 Delegation and alsoKnownAs features
+
+- Added support for delegator blocks in `service` section.
+- Added default `did:keri` and `did:web` alsoKnownAs entries in DID doc generation.
+
+### 0.3.1 repackage from dkr -> dws
+
+- fix HTTP stream consumption in logger middleware
+- add some test fixtures for ACDC schemas
+
+### 0.3.0 First release under GLEIF-IT/did-webs-resolver
+
+- Changed root package name to `dws` from `dkr` to reflect semantic name of did:webs.
+- Fixed broken constant imports, added missing constants.
+- Upgraded to KERI 1.2x.
+- Added `version` command.
+- Fixed logging and used TruncatedFormatter.
+- Refactored to use small functions all around for readability and testability.
+- Added unit and integration tests. 
+- Added output dir for DID artifacts instead of just default output dir.
+- Added sample script for local DID doc generation.
+- Fixed static file hosting and resolution to default to HTTPS and fall back to HTTP.
+- `--loglevel` arg added to CLI.
+- Idiomatic Hio usage for DoDoers
+- Corrected the `meta` field usage throughout the resolver.
+- `--verbose` argument added to CLI for more detailed output.
+- Fixed HTTP port conversion.
+- Removed all shelling out and replaced it with using the appropriate Doers for did:webs resolution.
+- Added code formatting.
+- Cleaned up the getting started docs.
+- Fixed the designated alias ACDC processing.
+- Removed the `--regname` argument in favor of scanning all local ACDC registries for self-attested designated alias ACDCs.
+- Added a complete end-to-end workflow script.
+- Added a health check endpoint to the did:webs resolver server.
+- Got rid of old, unused scripts and config.
+- Add support for path segments to the core.ends endpoints.
+- Add did_path for specifying where to host DID assets.
+- Fix HIO's urllib.parse of path in environ PATH_INFO.
+- Add integration style resolution tests and witness integration tests.
+- Make did:keri resolution work with OOBI resolution.
+- Get test coverage to 100%
+- Fix the docker compose setup to work with local test did:webs resolutions.
+- `X-Forwarded-Port` for supporting resolver deployments behind HTTP proxies.
+- Fix Location Scheme record save bug.
+
+#### 0.0.7 and before
+
+Initial draft. 
+- Partial implementation of did:webs resolver.
+- did:keri resolver imported from https://github.com/WebOfTrust/did-keri-resolver

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 	build-dynamic-service publish-dynamic-service tag-dynamic-service-latest \
 	build-did-webs-resolver-service publish-did-webs-resolver-service tag-did-webs-resolver-latest \
 	run-agent build-all publish-latest warn tag fmt check tag-latest-all
-VERSION=0.3.1  # also change in pyproject.toml and src/dws/__init__.py
+VERSION=0.3.2  # also change in pyproject.toml and src/dws/__init__.py
 
 RED="\033[0;31m"
 NO_COLOUR="\033[0m"
@@ -100,3 +100,8 @@ check:
 	uv tool run ruff check --select I
 	uv tool run ruff format --check
 
+build-pkg:
+	uv build
+
+publish-pkg:
+	uv publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,31 +1,36 @@
 [project]
-name = "dws"
-version = "0.3.1" # also change in src/dws/__init__.py and Makefile
+name = "did-webs-resolver"
+version = "0.3.2" # also change in src/dws/__init__.py and Makefile
 description = "did:webs DID Method Resolver"
 readme = "README.md"
 requires-python = "==3.12.6"
 license = {text = "Apache Software License 2.0"}
 authors = [
-    {name = "Philip S. Feairheller", email = "pfeairheller@gmail.com"}
+    {name = "Philip S. Feairheller", email = "pfeairheller@gmail.com"},
+    {name = "Kent O. P. Bull", email = "kent@kentbull.com"}
 ]
 keywords = ["did:webs", "did", "resolver", "webs", "keri", "acdc", "cesr", "vlei"]
 
 dependencies = [
-    "keri==1.2.6",
+    "keri==1.2.7",
     "multicommand>=1.0.0",
-    "falcon>=3.1.3",
-    "requests>=2.28",
-    "viking>=0.1.0",
+    "falcon>=4.0.2",
+    "requests>=2.32.5",
+    "viking>=0.1.1",
 ]
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.wheel]
+only-include = [ "src/dws" ]
+sources = [ "src" ]
+
 [project.urls]
-"Documentation" = "https://kara.readthedocs.io/"
-"Changelog" = "https://kara.readthedocs.io/en/latest/changelog.html"
-"Issue Tracker" = "https://github.com/WebOfTrust/kara/issues"
+"Documentation" = "https://github.com/GLEIF-IT/did-webs-resolver/docs"
+"Changelog" = "https://github.com/GLEIF-IT/did-webs-resolver/CHANGELOG.md"
+"Issue Tracker" = "https://github.com/GLEIF-IT/did-webs-resolver/issues"
 
 [project.scripts]
 dws = "dws.app.cli.dws:main"
@@ -39,4 +44,4 @@ dev = [
 ]
 
 [tool.uv.sources]
-viking = { git = "https://github.com/GLEIF-IT/viking" }
+viking = { git = "https://github.com/GLEIF-IT/viking.git", rev = "350745c33322a939ce307a87a1205b0ebaf4e491" }

--- a/src/dws/__init__.py
+++ b/src/dws/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.3.1'  # also change in pyproject.toml and Makefile
+__version__ = '0.3.2'  # also change in pyproject.toml and Makefile
 
 # Logging config
 import logging

--- a/src/dws/app/cli/dws.py
+++ b/src/dws/app/cli/dws.py
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 """
-kara.app.commands module
+dws.app.cli.commands module
 
 """
 

--- a/src/dws/core/didding.py
+++ b/src/dws/core/didding.py
@@ -420,6 +420,7 @@ def generate_did_doc(hby: habbing.Habery, rgy: credentialing.Regery, did, aid, m
     vms = generate_verification_methods(kever.verfers, kever.tholder.thold, did, aid)
 
     serv_ends = []
+    # TODO: move Location Scheme and Endpoint Role Authorization to dedicated function
     if hab and hasattr(hab, 'fetchRoleUrls'):
         ends = hab.fetchRoleUrls(cid=aid)
         serv_ends.extend(add_ends(ends))
@@ -428,6 +429,8 @@ def generate_did_doc(hby: habbing.Habery, rgy: credentialing.Regery, did, aid, m
     else:
         ends = habs.get_role_urls(baser=hby.db, kever=kever)
         serv_ends.extend(add_ends(ends))
+
+    # TODO: add delegation section if Hab is a delegated hab
 
     equiv_ids, aka_ids = get_equiv_aka_ids(did, aid, hby, rgy)
 

--- a/src/dws/core/didkeri.py
+++ b/src/dws/core/didkeri.py
@@ -82,8 +82,11 @@ class KeriResolver(doing.DoDoer):
         obr.cid = aid
         self.hby.db.oobis.pin(keys=(oobi,), val=obr)
 
-        while self.hby.db.roobi.get(keys=(oobi,)) is None:
+        while (
+            self.hby.db.roobi.get(keys=(oobi,)) is None or aid not in self.hby.kevers
+        ):  # wait for aid in hby.kevers waits for delegates to have their AES found
             now = helping.nowUTC()
+            self.hby.kvy.processEscrows()  # for delegated AIDs so authorizing event seals (AES) from delegator ixn evts are found
             if (now - start_time) > datetime.timedelta(seconds=self.TimeoutOOBIResolve):
                 raise kering.KeriError(f'OOBI resolution timed out after {self.TimeoutOOBIResolve} seconds for OOBI: {oobi}')
             _ = yield tock

--- a/src/dws/core/oobiing.py
+++ b/src/dws/core/oobiing.py
@@ -1,0 +1,8 @@
+from keri.app import habbing
+
+
+def get_resolved_oobi(hby: habbing.Habery, pre: str) -> str | None:
+    for (oobi,), obr in hby.db.roobi.getItemIter():
+        if obr.cid == pre:
+            return oobi
+    return None

--- a/src/dws/core/resolving.py
+++ b/src/dws/core/resolving.py
@@ -604,7 +604,10 @@ def resolve_did_keri(hby: habbing.Habery, rgy: credentialing.Regery, did: str, o
     obr = basing.OobiRecord(date=helping.nowIso8601())
     obr.cid = aid
     hby.db.oobis.pin(keys=(oobi,), val=obr)
-    while hby.db.roobi.get(keys=(oobi,)) is None:
+    while (
+        hby.db.roobi.get(keys=(oobi,)) is None or aid not in hby.kevers
+    ):  # wait for aid in hby.kevers waits for delegates to have their AES found
         doist.recur(deeds)
+        hby.kvy.processEscrows()  # for delegated AIDs so authorizing event seals (AES) from delegator ixn evts are found
 
     return True, didding.generate_did_doc(hby, rgy, did=did, aid=aid, meta=meta)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ https://docs.pytest.org/en/latest/pythonpath.html
 """
 
 import json
+from collections import deque
 from contextlib import contextmanager
 from pathlib import Path
 from typing import List, Union
@@ -80,7 +81,7 @@ class CredentialHelpers:
         private: bool = False,
         private_credential_nonce: str = None,
         private_subject_nonce: str = None,
-        additional_deeds: List[doing.Doer] = None,
+        additional_deeds: deque = None,
     ):
         """Issues a credential with a given AID using the schema, subject data, rules, edges (source), and recipient (recp)."""
         additional_deeds = additional_deeds or decking.deque(

--- a/tests/dws/core/test_didding.py
+++ b/tests/dws/core/test_didding.py
@@ -683,6 +683,7 @@ def test_generate_did_doc_single_sig_meta(mock_helping_now_utc):
     unstub()
 
 
+# TODO read through the multisig test
 def test_generate_did_doc_multi_sig():
     hby = mock()
     hby.name = 'test_hby'
@@ -1115,3 +1116,6 @@ def test_designated_aliases_generation_returns_creds_when_non_local_aid():
     when(rgy.reger).cloneCreds([test_saider], hby.db).thenReturn([])
     da = didding.gen_designated_aliases(hby, rgy, 'test_aid')
     assert da == [], 'Expected empty list for designated aliases when no credentials are found'
+
+def test_generate_did_doc_with_delegator_shows_service_delegator_section():
+    pass

--- a/tests/dws/core/test_didding.py
+++ b/tests/dws/core/test_didding.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 import pytest
 from hio.help.hicting import Mict
 from keri.app import habbing
-from keri.core import coring, serdering
+from keri.core import coring, eventing, serdering
 from keri.db import basing, koming, subing
 from keri.vdr import credentialing, verifying
 from mockito import mock, unstub, when
@@ -214,6 +214,47 @@ def test_generate_did_doc_unknown_aid():
     )
 
 
+def role_urls_fixture():
+    return Mict(
+        [
+            (
+                'controller',
+                Mict(
+                    [
+                        (
+                            'BKVb58uITf48YoMPz8SBOTVwLgTO9BY4oEXRPoYIOErX',
+                            Mict(
+                                [
+                                    ('http', 'http://localhost:8080/witness/wok'),
+                                    ('tcp', 'tcp://localhost:8080/witness/wok'),
+                                ]
+                            ),
+                        )
+                    ]
+                ),
+            )
+        ]
+    )
+
+
+def witness_urls_fixture():
+    return Mict(
+        [
+            (
+                'witness',
+                Mict(
+                    [
+                        (
+                            'BKVb58uITf48YoMPz8SBOTVwLgTO9BY4oEXRPoYIOErX',
+                            Mict([('http', 'http://localhost:8080/witness/wok')]),
+                        )
+                    ]
+                ),
+            )
+        ]
+    )
+
+
 def test_generate_did_doc_single_sig():
     hby = mock()
     hby.name = 'test_hby'
@@ -248,45 +289,8 @@ def test_generate_did_doc_single_sig():
     loc = basing.LocationRecord(url='tcp://127.0.0.1:5634/')
     when(db.locs).getItemIter(keys=(aid,)).thenReturn([((aid, 'some_key'), loc)])
 
-    when(hab).fetchRoleUrls(cid=aid).thenReturn(
-        Mict(
-            [
-                (
-                    'controller',
-                    Mict(
-                        [
-                            (
-                                'BKVb58uITf48YoMPz8SBOTVwLgTO9BY4oEXRPoYIOErX',
-                                Mict(
-                                    [
-                                        ('http', 'http://localhost:8080/witness/wok'),
-                                        ('tcp', 'tcp://localhost:8080/witness/wok'),
-                                    ]
-                                ),
-                            )
-                        ]
-                    ),
-                )
-            ]
-        )
-    )
-    when(hab).fetchWitnessUrls(cid=aid).thenReturn(
-        Mict(
-            [
-                (
-                    'witness',
-                    Mict(
-                        [
-                            (
-                                'BKVb58uITf48YoMPz8SBOTVwLgTO9BY4oEXRPoYIOErX',
-                                Mict([('http', 'http://localhost:8080/witness/wok')]),
-                            )
-                        ]
-                    ),
-                )
-            ]
-        )
-    )
+    when(hab).fetchRoleUrls(cid=aid).thenReturn(role_urls_fixture())
+    when(hab).fetchWitnessUrls(cid=aid).thenReturn(witness_urls_fixture())
 
     rgy = mock()
     issus = mock()
@@ -373,40 +377,8 @@ def test_generate_did_doc_single_sig_with_designated_alias(mock_helping_now_utc)
     loc = basing.LocationRecord(url='tcp://127.0.0.1:5634/')
     when(db.locs).getItemIter(keys=(aid,)).thenReturn([((aid, 'some_key'), loc)])
 
-    when(hab).fetchRoleUrls(cid=aid).thenReturn(
-        Mict(
-            [
-                (
-                    'controller',
-                    Mict(
-                        [
-                            (
-                                'BKVb58uITf48YoMPz8SBOTVwLgTO9BY4oEXRPoYIOErX',
-                                Mict([('http', 'http://localhost:8080/witness/wok')]),
-                            )
-                        ]
-                    ),
-                )
-            ]
-        )
-    )
-    when(hab).fetchWitnessUrls(cid=aid).thenReturn(
-        Mict(
-            [
-                (
-                    'witness',
-                    Mict(
-                        [
-                            (
-                                'BKVb58uITf48YoMPz8SBOTVwLgTO9BY4oEXRPoYIOErX',
-                                Mict([('http', 'http://localhost:8080/witness/wok')]),
-                            )
-                        ]
-                    ),
-                )
-            ]
-        )
-    )
+    when(hab).fetchRoleUrls(cid=aid).thenReturn(role_urls_fixture())
+    when(hab).fetchWitnessUrls(cid=aid).thenReturn(witness_urls_fixture())
 
     rgy = mock()
     issus = mock()
@@ -451,7 +423,7 @@ def test_generate_did_doc_single_sig_with_designated_alias(mock_helping_now_utc)
             {
                 'id': '#BKVb58uITf48YoMPz8SBOTVwLgTO9BY4oEXRPoYIOErX/controller',
                 'type': 'controller',
-                'serviceEndpoint': {'http': 'http://localhost:8080/witness/wok'},
+                'serviceEndpoint': {'http': 'http://localhost:8080/witness/wok', 'tcp': 'tcp://localhost:8080/witness/wok'},
             },
             {
                 'id': '#BKVb58uITf48YoMPz8SBOTVwLgTO9BY4oEXRPoYIOErX/witness',
@@ -467,40 +439,8 @@ def test_generate_did_doc_single_sig_with_designated_alias(mock_helping_now_utc)
     loc = basing.LocationRecord(url='tcp://127.0.0.1:5634/')
     when(db.locs).getItemIter(keys=(aid,)).thenReturn([((aid, 'some_key'), loc)])
 
-    when(hab).fetchRoleUrls(cid=aid).thenReturn(
-        Mict(
-            [
-                (
-                    'controller',
-                    Mict(
-                        [
-                            (
-                                'BKVb58uITf48YoMPz8SBOTVwLgTO9BY4oEXRPoYIOErX',
-                                Mict([('http', 'http://localhost:8080/witness/wok')]),
-                            )
-                        ]
-                    ),
-                )
-            ]
-        )
-    )
-    when(hab).fetchWitnessUrls(cid=aid).thenReturn(
-        Mict(
-            [
-                (
-                    'witness',
-                    Mict(
-                        [
-                            (
-                                'BKVb58uITf48YoMPz8SBOTVwLgTO9BY4oEXRPoYIOErX',
-                                Mict([('http', 'http://localhost:8080/witness/wok')]),
-                            )
-                        ]
-                    ),
-                )
-            ]
-        )
-    )
+    when(hab).fetchRoleUrls(cid=aid).thenReturn(role_urls_fixture())
+    when(hab).fetchWitnessUrls(cid=aid).thenReturn(witness_urls_fixture())
     when(credentialing).Regery(hby=hby, name=hby.name).thenReturn(rgy)
     when(verifying).Verifier(hby=hby, reger=rgy.reger).thenReturn(vry)
 
@@ -537,7 +477,10 @@ def test_generate_did_doc_single_sig_with_designated_alias(mock_helping_now_utc)
                 {
                     'id': '#BKVb58uITf48YoMPz8SBOTVwLgTO9BY4oEXRPoYIOErX/controller',
                     'type': 'controller',
-                    'serviceEndpoint': {'http': 'http://localhost:8080/witness/wok'},
+                    'serviceEndpoint': {
+                        'http': 'http://localhost:8080/witness/wok',
+                        'tcp': 'tcp://localhost:8080/witness/wok',
+                    },
                 },
                 {
                     'id': '#BKVb58uITf48YoMPz8SBOTVwLgTO9BY4oEXRPoYIOErX/witness',
@@ -589,40 +532,8 @@ def test_generate_did_doc_single_sig_meta(mock_helping_now_utc):
     loc = basing.LocationRecord(url='tcp://127.0.0.1:5634/')
     when(db.locs).getItemIter(keys=(aid,)).thenReturn([((aid, 'some_key'), loc)])
 
-    when(hab).fetchRoleUrls(cid=aid).thenReturn(
-        Mict(
-            [
-                (
-                    'controller',
-                    Mict(
-                        [
-                            (
-                                'BKVb58uITf48YoMPz8SBOTVwLgTO9BY4oEXRPoYIOErX',
-                                Mict([('http', 'http://localhost:8080/witness/wok')]),
-                            )
-                        ]
-                    ),
-                )
-            ]
-        )
-    )
-    when(hab).fetchWitnessUrls(cid=aid).thenReturn(
-        Mict(
-            [
-                (
-                    'witness',
-                    Mict(
-                        [
-                            (
-                                'BKVb58uITf48YoMPz8SBOTVwLgTO9BY4oEXRPoYIOErX',
-                                Mict([('http', 'http://localhost:8080/witness/wok')]),
-                            )
-                        ]
-                    ),
-                )
-            ]
-        )
-    )
+    when(hab).fetchRoleUrls(cid=aid).thenReturn(role_urls_fixture())
+    when(hab).fetchWitnessUrls(cid=aid).thenReturn(witness_urls_fixture())
 
     rgy = mock()
     issus = mock()
@@ -662,7 +573,10 @@ def test_generate_did_doc_single_sig_meta(mock_helping_now_utc):
                 {
                     'id': '#BKVb58uITf48YoMPz8SBOTVwLgTO9BY4oEXRPoYIOErX/controller',
                     'type': 'controller',
-                    'serviceEndpoint': {'http': 'http://localhost:8080/witness/wok'},
+                    'serviceEndpoint': {
+                        'http': 'http://localhost:8080/witness/wok',
+                        'tcp': 'tcp://localhost:8080/witness/wok',
+                    },
                 },
                 {
                     'id': '#BKVb58uITf48YoMPz8SBOTVwLgTO9BY4oEXRPoYIOErX/witness',
@@ -686,7 +600,6 @@ def test_generate_did_doc_single_sig_meta(mock_helping_now_utc):
     unstub()
 
 
-# TODO read through the multisig test
 def test_generate_did_doc_multi_sig():
     hby = mock()
     hby.name = 'test_hby'
@@ -724,40 +637,8 @@ def test_generate_did_doc_multi_sig():
     loc = basing.LocationRecord(url='tcp://127.0.0.1:5634/')
     when(db.locs).getItemIter(keys=(aid,)).thenReturn([((aid, 'some_key'), loc)])
 
-    when(hab).fetchRoleUrls(cid=aid).thenReturn(
-        Mict(
-            [
-                (
-                    'controller',
-                    Mict(
-                        [
-                            (
-                                'BKVb58uITf48YoMPz8SBOTVwLgTO9BY4oEXRPoYIOErX',
-                                Mict([('http', 'http://localhost:8080/witness/wok')]),
-                            )
-                        ]
-                    ),
-                )
-            ]
-        )
-    )
-    when(hab).fetchWitnessUrls(cid=aid).thenReturn(
-        Mict(
-            [
-                (
-                    'witness',
-                    Mict(
-                        [
-                            (
-                                'BKVb58uITf48YoMPz8SBOTVwLgTO9BY4oEXRPoYIOErX',
-                                Mict([('http', 'http://localhost:8080/witness/wok')]),
-                            )
-                        ]
-                    ),
-                )
-            ]
-        )
-    )
+    when(hab).fetchRoleUrls(cid=aid).thenReturn(role_urls_fixture())
+    when(hab).fetchWitnessUrls(cid=aid).thenReturn(witness_urls_fixture())
 
     rgy = mock()
     issus = mock()
@@ -817,7 +698,7 @@ def test_generate_did_doc_multi_sig():
             {
                 'id': '#BKVb58uITf48YoMPz8SBOTVwLgTO9BY4oEXRPoYIOErX/controller',
                 'type': 'controller',
-                'serviceEndpoint': {'http': 'http://localhost:8080/witness/wok'},
+                'serviceEndpoint': {'http': 'http://localhost:8080/witness/wok', 'tcp': 'tcp://localhost:8080/witness/wok'},
             },
             {
                 'id': '#BKVb58uITf48YoMPz8SBOTVwLgTO9BY4oEXRPoYIOErX/witness',
@@ -834,40 +715,8 @@ def test_generate_did_doc_multi_sig():
 
     when(db.locs).getItemIter(keys=(aid,)).thenReturn([((aid, 'some_key'), loc)])
 
-    when(hab).fetchRoleUrls(cid=aid).thenReturn(
-        Mict(
-            [
-                (
-                    'controller',
-                    Mict(
-                        [
-                            (
-                                'BKVb58uITf48YoMPz8SBOTVwLgTO9BY4oEXRPoYIOErX',
-                                Mict([('http', 'http://localhost:8080/witness/wok')]),
-                            )
-                        ]
-                    ),
-                )
-            ]
-        )
-    )
-    when(hab).fetchWitnessUrls(cid=aid).thenReturn(
-        Mict(
-            [
-                (
-                    'witness',
-                    Mict(
-                        [
-                            (
-                                'BKVb58uITf48YoMPz8SBOTVwLgTO9BY4oEXRPoYIOErX',
-                                Mict([('http', 'http://localhost:8080/witness/wok')]),
-                            )
-                        ]
-                    ),
-                )
-            ]
-        )
-    )
+    when(hab).fetchRoleUrls(cid=aid).thenReturn(role_urls_fixture())
+    when(hab).fetchWitnessUrls(cid=aid).thenReturn(witness_urls_fixture())
     when(credentialing).Regery(hby=hby, name=hby.name).thenReturn(rgy)
     when(verifying).Verifier(hby=hby, reger=rgy.reger).thenReturn(vry)
 
@@ -918,7 +767,7 @@ def test_generate_did_doc_multi_sig():
             {
                 'id': '#BKVb58uITf48YoMPz8SBOTVwLgTO9BY4oEXRPoYIOErX/controller',
                 'type': 'controller',
-                'serviceEndpoint': {'http': 'http://localhost:8080/witness/wok'},
+                'serviceEndpoint': {'http': 'http://localhost:8080/witness/wok', 'tcp': 'tcp://localhost:8080/witness/wok'},
             },
             {
                 'id': '#BKVb58uITf48YoMPz8SBOTVwLgTO9BY4oEXRPoYIOErX/witness',
@@ -1153,4 +1002,26 @@ def test_gen_delegation_service_no_oobi_returns_none():
     when(hby.db).fetchLastSealingEventByEventSeal(pre='delegator_aid', seal=seal_evt).thenReturn(mockSealSerder)
     when(hby.db.roobi).getItemIter().thenReturn([])
 
-    assert didding.gen_delegation_service(hby=hby, pre='delegate_aid', delpre='delegator_aid') is None
+    assert didding.gen_delegation_service(hby=hby, pre='delegate_aid', delpre='delegator_aid') == []
+
+
+def test_gen_service_endpoints_when_del_serv_end_is_none_does_not_include_delegator_service():
+    aid = 'delegate_aid'
+    seal_evt = dict(i='delegate_aid', s='0', d='delegate_aid')
+    mockSealSerder = mock(serdering.SerderKERI)
+    mockSealSerder.sad = {'a': [{'d': 'delegator_aid'}]}
+
+    hby = mock(habbing.Habery)
+    hby.db = mock(basing.Baser)
+    hby.db.roobi = mock(koming.Komer)
+    when(hby.db).fetchLastSealingEventByEventSeal(pre='delegator_aid', seal=seal_evt).thenReturn(mockSealSerder)
+    when(hby.db.roobi).getItemIter().thenReturn([])
+
+    hab = mock(habbing.Hab)
+    kever = mock(eventing.Kever)
+    when(hab).fetchRoleUrls(cid=aid).thenReturn(role_urls_fixture())
+    when(hab).fetchWitnessUrls(cid=aid).thenReturn(witness_urls_fixture())
+
+    serv_endpoints = didding.gen_service_endpoints(hby=hby, hab=hab, kever=kever, aid='delegate_aid')
+    assert len(serv_endpoints) > 0, 'Service endpoints should not be empty'
+    assert 'DelegatorOOBI' not in [service['type'] for service in serv_endpoints], 'Delegator service should not be included'

--- a/tests/dws/core/test_didding.py
+++ b/tests/dws/core/test_didding.py
@@ -11,8 +11,8 @@ from unittest.mock import patch
 import pytest
 from hio.help.hicting import Mict
 from keri.app import habbing
-from keri.core import coring
-from keri.db import basing, subing
+from keri.core import coring, serdering
+from keri.db import basing, koming, subing
 from keri.vdr import credentialing, verifying
 from mockito import mock, unstub, when
 
@@ -229,6 +229,7 @@ def test_generate_did_doc_single_sig():
     aid = 'EKYLUMmNPZeEs77Zvclf0bSN5IN-mLfLpx2ySb-HDlk4'
     hab.name = 'test_hab'
     hab.db = hab_db
+    hab.delpre = None
     hby.habs = {aid: hab}
     sner = mock()
     sner.num = 0
@@ -353,6 +354,7 @@ def test_generate_did_doc_single_sig_with_designated_alias(mock_helping_now_utc)
     aid = 'EKYLUMmNPZeEs77Zvclf0bSN5IN-mLfLpx2ySb-HDlk4'
     hab.name = 'test_hab'
     hab.db = hab_db
+    hab.delpre = None
     hby.habs = {aid: hab}
     sner = mock()
     sner.num = 0
@@ -565,6 +567,7 @@ def test_generate_did_doc_single_sig_meta(mock_helping_now_utc):
     aid = 'EKYLUMmNPZeEs77Zvclf0bSN5IN-mLfLpx2ySb-HDlk4'
     hab.name = 'test_hab'
     hab.db = hab_db
+    hab.delpre = None
     hby.habs = {aid: hab}
     sner = mock()
     sner.num = 0
@@ -699,6 +702,7 @@ def test_generate_did_doc_multi_sig():
     did = 'did:web:127.0.0.1%3A7676:EKYLUMmNPZeEs77Zvclf0bSN5IN-mLfLpx2ySb-HDlk4'
     aid = 'EKYLUMmNPZeEs77Zvclf0bSN5IN-mLfLpx2ySb-HDlk4'
     hab.name = 'test_hab'
+    hab.delpre = None
     hab.db = hab_db
     hby.habs = {aid: hab}
     sner = mock()
@@ -1117,5 +1121,36 @@ def test_designated_aliases_generation_returns_creds_when_non_local_aid():
     da = didding.gen_designated_aliases(hby, rgy, 'test_aid')
     assert da == [], 'Expected empty list for designated aliases when no credentials are found'
 
+
 def test_generate_did_doc_with_delegator_shows_service_delegator_section():
     pass
+
+
+def test_gen_delegation_service_generates_correctly():
+    seal_evt = dict(i='delegate_aid', s='0', d='delegate_aid')
+    mockSealSerder = mock(serdering.SerderKERI)
+    mockSealSerder.sad = {'a': [{'d': 'delegator_aid'}]}
+
+    hby = mock(habbing.Habery)
+    hby.db = mock(basing.Baser)
+    hby.db.roobi = mock(koming.Komer)
+    when(hby.db).fetchLastSealingEventByEventSeal(pre='delegator_aid', seal=seal_evt).thenReturn(mockSealSerder)
+    oobi = 'http://example.com/oobi/delegate_aid'
+    obr = basing.OobiRecord(cid='delegator_aid')
+    when(hby.db.roobi).getItemIter().thenReturn([((oobi,), obr)])
+
+    assert didding.gen_delegation_service(hby=hby, pre='delegate_aid', delpre='delegator_aid')
+
+
+def test_gen_delegation_service_no_oobi_returns_none():
+    seal_evt = dict(i='delegate_aid', s='0', d='delegate_aid')
+    mockSealSerder = mock(serdering.SerderKERI)
+    mockSealSerder.sad = {'a': [{'d': 'delegator_aid'}]}
+
+    hby = mock(habbing.Habery)
+    hby.db = mock(basing.Baser)
+    hby.db.roobi = mock(koming.Komer)
+    when(hby.db).fetchLastSealingEventByEventSeal(pre='delegator_aid', seal=seal_evt).thenReturn(mockSealSerder)
+    when(hby.db.roobi).getItemIter().thenReturn([])
+
+    assert didding.gen_delegation_service(hby=hby, pre='delegate_aid', delpre='delegator_aid') is None

--- a/tests/keri_api.py
+++ b/tests/keri_api.py
@@ -1,0 +1,222 @@
+from typing import List
+
+from hio.base import doing, Doer
+from hio.help import decking
+from hio.help.decking import Deck
+from keri import kering
+from keri.app import habbing, oobiing
+from keri.app.agenting import Receiptor, WitnessReceiptor
+from keri.app.delegating import Anchorer
+from keri.app.forwarding import Poster
+from keri.app.habbing import Habery, Hab
+from keri.core.coring import Seqner
+from keri.db import basing
+from keri.db.basing import Baser
+from keri.help import helping
+
+
+def delegate_confirm_single_sig(del_deeds, dgt_deeds, wit_deeds):
+    """
+    Perform single sig delegation approval; equivalent of `kli delegate confirm`
+    Uses deeds created from a Doist in the context of a test.
+    """
+
+class HabHelpers:
+    @staticmethod
+    def generate_oobi(hby: habbing.Habery, alias: str = None, role: str = kering.Roles.witness):
+        hab = hby.habByName(name=alias)
+        oobi = ''
+        if role in (kering.Roles.witness,):
+            if not hab.kever.wits:
+                raise kering.ConfigurationError(f"{alias} identifier {hab.pre} does not have any witnesses.")
+            for wit in hab.kever.wits:
+                urls = hab.fetchUrls(eid=wit, scheme=kering.Schemes.http) \
+                       or hab.fetchUrls(eid=wit, scheme=kering.Schemes.https)
+                if not urls:
+                    raise kering.ConfigurationError(f"unable to query witness {wit}, no http endpoint")
+
+                url = urls[kering.Schemes.https] if kering.Schemes.https in urls else urls[kering.Schemes.http]
+                oobi = f"{url.rstrip("/")}/oobi/{hab.pre}/witness"
+        elif role in (kering.Roles.controller,):
+            urls = hab.fetchUrls(eid=hab.pre, scheme=kering.Schemes.http) \
+                   or hab.fetchUrls(eid=hab.pre, scheme=kering.Schemes.https)
+            if not urls:
+                raise kering.ConfigurationError(f"{alias} identifier {hab.pre} does not have any controller endpoints")
+            url = urls[kering.Schemes.https] if kering.Schemes.https in urls else urls[kering.Schemes.http]
+            oobi = f"{url.rstrip("/")}/oobi/{hab.pre}/controller"
+        elif role in (kering.Roles.mailbox,):
+            for (_, _, eid), end in hab.db.ends.getItemIter(keys=(hab.pre, kering.Roles.mailbox, )):
+                if not (end.allowed and end.enabled is not False):
+                    continue
+
+                urls = hab.fetchUrls(eid=eid, scheme=kering.Schemes.http) or hab.fetchUrls(eid=hab.pre,
+                                                                                           scheme=kering.Schemes.https)
+                if not urls:
+                    raise kering.ConfigurationError(f"{alias} identifier {hab.pre} does not have any mailbox endpoints")
+                url = urls[kering.Schemes.https] if kering.Schemes.https in urls else urls[kering.Schemes.http]
+                oobi = f"{url.rstrip("/")}/oobi/{hab.pre}/mailbox/{eid}"
+        if oobi:
+            return oobi
+        else:
+            raise kering.ConfigurationError(f"Unable to generate OOBI for {alias} identifier {hab.pre} with role {role}")
+
+    @staticmethod
+    def resolve_wit_oobi(doist: doing.Doist, wit_deeds: List[Doer], hby: habbing.Habery, oobi: str, alias: str = None):
+        """Resolve an OOBI depending on a given witness for a given Habery."""
+        obr = basing.OobiRecord(date=helping.nowIso8601())
+        if alias is not None:
+            obr.oobialias = alias
+        hby.db.oobis.put(keys=(oobi,), val=obr)
+
+        oobiery = oobiing.Oobiery(hby=hby)
+        authn = oobiing.Authenticator(hby=hby)
+        oobiery_deeds = doist.enter(doers=oobiery.doers + authn.doers)
+        while not oobiery.hby.db.roobi.get(keys=(oobi,)):
+            doist.recur(deeds=decking.Deck(wit_deeds + oobiery_deeds))
+            hby.kvy.processEscrows()  # process any escrows from witness receipts
+
+    @staticmethod
+    def has_delegables(db: Baser):
+        dlgs = []
+        for (pre, sn), edig in db.delegables.getItemIter():
+            dlgs.append((pre, sn, edig))
+        return dlgs
+
+class DelegationAutoApprover(doing.Doer):
+    """
+    Automatically approves delegation requests for testing purposes.
+    """
+    def __init__(self):
+        super(DelegationAutoApprover, self).__init__()
+
+    def recur(self, tock=0.0, **opts):
+        pass
+
+
+class Dipper(doing.DoDoer):
+    """
+    Handles the delegation lifecycle for single-sig identifiers from the perspective of the delegate.
+
+    Assumes the delegate Hab is already made and that only witness receipts, delegation approval, and
+    waiting for completion are needed.
+    """
+    def __init__(self, hby: Habery, hab: Hab, proxy: str = None, endpoint: str = None):
+        self.hby = hby
+        self.hab = hab
+        self.proxy = self.hby.habByName(proxy) if proxy is not None else None
+        self.sender = proxy if proxy is not None else hab
+        self.endpoint = endpoint
+        self.postman = Poster(hby=self.hby)
+        self.cues = decking.Deck()
+
+        # Doers
+        self.anchorer = Anchorer(hby=self.hby, proxy=self.proxy)
+        self.icpCompleter = DipCompleter(self.anchorer, self.hab, self.cues)
+        # TODO maybe witReceiptor and receiptor are not needed since the Anchorer makes its own?
+        self.witReceiptor = WitnessReceiptor(hby=self.hby)
+        self.receiptor = Receiptor(hby=self.hby)
+        self.receiptWaiter = ReceiptWaiter(pre=self.hab.pre, sn=0, cues=self.cues, endpoint=self.endpoint,
+                                           witReceiptor = self.witReceiptor, receiptor=self.receiptor)
+        self.dipSender = DipSender(hab=self.hab, sender=self.sender, cues=self.cues, postman=self.postman)
+        doers: List[Doer] = [self.icpCompleter, self.witReceiptor, self.receiptor, self.postman, self.dipSender]
+        if hab.kever.wits:
+            doers.append(self.receiptWaiter)
+        super(Dipper, self).__init__(doers=doers)
+
+    def recur(self, tyme, deeds=None):
+        if self.cues:
+            for cue in self.cues:
+                kin = cue.get("kin", "")
+                if kin == "dipSent":
+                    print(f"Delegated inception process complete for {self.hab.pre}.")
+                    self.remove(self.doers)  # remove any remaining doers
+                    return True  # done
+        super(Dipper, self).recur(tyme, deeds=deeds)
+        return False  # not done yet
+
+class ReceiptWaiter(doing.Doer):
+    """
+    Waits for a receiptor to finish receipting and then publishes a receipt completion cue.
+    """
+    def __init__(self, pre: str, sn: int, cues: decking.Deck, endpoint: str,
+                 witReceiptor: WitnessReceiptor, receiptor: Receiptor):
+        self.pre = pre
+        self.sn = sn
+        self.cues = cues
+        self.endpoint = endpoint
+        self.witReceiptor = witReceiptor
+        self.receiptor = receiptor
+        super(ReceiptWaiter, self).__init__()
+
+    def waitOnReceipts(self):
+        """Uses Receiptor to propagage """
+        if self.endpoint:
+            yield from self.receiptor.receipt(pre=self.pre, sn=self.sn)
+        else:
+            self.witReceiptor.msgs.append(dict(pre=self.pre))
+            while not self.witReceiptor.cues:
+                _ = yield self.tock
+
+    def recur(self, tock=0.0, **opts):
+        while True:
+            while self.cues:
+                cue = self.cues.popleft()
+                cueKin = cue["kin"]
+                if cueKin == "delComplete":
+                    yield from self.waitOnReceipts()
+                    print(f"Receipts obtained for {self.pre} at sn {self.sn}, cueing completion.")
+                    self.cues.append({'cueKin': 'rctComplete', 'pre': self.pre, 'sn': self.sn})
+                    return True
+                yield tock
+            yield tock
+
+class DipSender(doing.Doer):
+    """
+    Sends the delegated inception event to the delegator.
+    """
+    def __init__(self, hab: Hab, sender: str, cues: Deck, postman: Poster):
+        self.hab = hab
+        self.sender = sender
+        self.cues = cues
+        self.postman = postman
+        super(DipSender, self).__init__()
+
+    def sendDip(self):
+        yield from self.postman.sendEventToDelegator(
+            hab=self.hab,
+            sender=self.sender,
+            fn=self.hab.kever.sn)
+
+    def recur(self, tock=0.0, **opts):
+        while True:
+            while self.cues:
+                cue = self.cues.popleft()
+                cueKin = cue["kin"]
+                if cueKin == "rctComplete":
+                    print(f"Sending delegated inception event for {self.hab.pre} to delegator...")
+                    yield from self.sendDip()
+                    self.cues.append({'kin': 'dipSent', 'pre': self.hab.pre})
+                    return True
+                yield tock
+            yield tock
+
+class DipCompleter(doing.Doer):
+    """
+    Completes the delegated inception process by waiting for delegation approval.
+    """
+    def __init__(self, anchorer: Anchorer, hab: Hab, cues: Deck):
+        self.anchorer = anchorer
+        self.hab = hab
+        self.cues = cues
+        super(DipCompleter, self).__init__()
+
+    def recur(self, tock=0.0, **opts):
+        self.anchorer.delegation(pre=self.hab.pre, sn=0)
+        print(f"Waiting for delegation approval for {self.hab.kever.prefixer.qb64}...")
+        while not self.anchorer.complete(self.hab.kever.prefixer, Seqner(sn=self.hab.kever.sn)):
+            yield self.tock
+        print(f"Delegation approved for {self.hab.kever.prefixer.qb64}, cueing completion.")
+        self.cues.append({'kin': 'delComplete', 'pre': self.hab.pre})
+        return True
+
+

--- a/tests/keri_api.py
+++ b/tests/keri_api.py
@@ -5,12 +5,13 @@ from hio.help import decking
 from hio.help.decking import Deck
 from keri import kering
 from keri.app import habbing, oobiing
-from keri.app.agenting import Receiptor, WitnessReceiptor
+from keri.app.agenting import WitnessReceiptor, WitnessInquisitor
 from keri.app.delegating import Anchorer
 from keri.app.forwarding import Poster
-from keri.app.habbing import Habery, Hab
+from keri.app.habbing import Habery, Hab, GroupHab
+from keri.core import serdering, coring
 from keri.core.coring import Seqner
-from keri.db import basing
+from keri.db import basing, dbing
 from keri.db.basing import Baser
 from keri.help import helping
 
@@ -99,124 +100,269 @@ class Dipper(doing.DoDoer):
 
     Assumes the delegate Hab is already made and that only witness receipts, delegation approval, and
     waiting for completion are needed.
+
+    TODO add 2FA witness support (auths)
     """
-    def __init__(self, hby: Habery, hab: Hab, proxy: str = None, endpoint: str = None):
+    def __init__(self, hby: Habery, hab: Hab, proxy: str = None):
+        """
+        Constructs the subtasks for Dipper. Assumes the delegate Hab is already created.
+        Adds a witness receiptor if the delegate is using witnesses.
+        Assumes something else is running the HaberyDoer, Poster, and MailboxDirector
+
+        TODO maybe witReceiptor and receiptor are not needed since the Anchorer makes its own?
+        """
         self.hby = hby
         self.hab = hab
         self.proxy = self.hby.habByName(proxy) if proxy is not None else None
         self.sender = proxy if proxy is not None else hab
-        self.endpoint = endpoint
         self.postman = Poster(hby=self.hby)
         self.cues = decking.Deck()
 
-        # Doers
+        # Doers - async tasks
         self.anchorer = Anchorer(hby=self.hby, proxy=self.proxy)
-        self.icpCompleter = DipCompleter(self.anchorer, self.hab, self.cues)
-        # TODO maybe witReceiptor and receiptor are not needed since the Anchorer makes its own?
+        self.icpCompleter = DipSender(self.anchorer, self.hab, self.cues)
         self.witReceiptor = WitnessReceiptor(hby=self.hby)
-        self.receiptor = Receiptor(hby=self.hby)
-        self.receiptWaiter = ReceiptWaiter(pre=self.hab.pre, sn=0, cues=self.cues, endpoint=self.endpoint,
-                                           witReceiptor = self.witReceiptor, receiptor=self.receiptor)
-        self.dipSender = DipSender(hab=self.hab, sender=self.sender, cues=self.cues, postman=self.postman)
-        doers: List[Doer] = [self.icpCompleter, self.witReceiptor, self.receiptor, self.postman, self.dipSender]
+        self.receiptWaiter = ReceiptWaiter(pre=self.hab.pre, sn=0, cues=self.cues, witReceiptor = self.witReceiptor)
+        self.dipSender = DipPublisher(hab=self.hab, proxy=self.proxy, cues=self.cues, postman=self.postman)
+        doers: List[Doer] = [self.anchorer, self.icpCompleter, self.witReceiptor, self.postman, self.dipSender]
         if hab.kever.wits:
             doers.append(self.receiptWaiter)
         super(Dipper, self).__init__(doers=doers)
 
     def recur(self, tyme, deeds=None):
-        if self.cues:
-            for cue in self.cues:
-                kin = cue.get("kin", "")
-                if kin == "dipSent":
-                    print(f"Delegated inception process complete for {self.hab.pre}.")
-                    self.remove(self.doers)  # remove any remaining doers
-                    return True  # done
-        super(Dipper, self).recur(tyme, deeds=deeds)
+        """Consumes dipSent and cleans up doers, completing this DoDoer."""
+        super(Dipper, self).recur(tyme, deeds=deeds)  # plumbing call to DoDoer superclass - required
+        while self.cues:
+            cue = self.cues.popleft()
+            kin = cue.get("kin", "")
+            if kin == "delComplete":
+                self.cues.append({'kin': 'rctWait'})
+                return False  # wait on receipts - not done yet
+            elif kin == "rctComplete":
+                self.cues.append({'kin': 'dipPublish'})
+                return False  # publish dip - not done yet
+            elif kin == "dipSent":
+                print(f"Delegated inception process complete for {self.hab.pre}.")
+                self.remove(self.doers)  # remove any remaining doers
+                return True  # done
+            else:
+                self.cues.append(cue)
+            return False  # not done yet
         return False  # not done yet
-
-class ReceiptWaiter(doing.Doer):
-    """
-    Waits for a receiptor to finish receipting and then publishes a receipt completion cue.
-    """
-    def __init__(self, pre: str, sn: int, cues: decking.Deck, endpoint: str,
-                 witReceiptor: WitnessReceiptor, receiptor: Receiptor):
-        self.pre = pre
-        self.sn = sn
-        self.cues = cues
-        self.endpoint = endpoint
-        self.witReceiptor = witReceiptor
-        self.receiptor = receiptor
-        super(ReceiptWaiter, self).__init__()
-
-    def waitOnReceipts(self):
-        """Uses Receiptor to propagage """
-        if self.endpoint:
-            yield from self.receiptor.receipt(pre=self.pre, sn=self.sn)
-        else:
-            self.witReceiptor.msgs.append(dict(pre=self.pre))
-            while not self.witReceiptor.cues:
-                _ = yield self.tock
-
-    def recur(self, tock=0.0, **opts):
-        while True:
-            while self.cues:
-                cue = self.cues.popleft()
-                cueKin = cue["kin"]
-                if cueKin == "delComplete":
-                    yield from self.waitOnReceipts()
-                    print(f"Receipts obtained for {self.pre} at sn {self.sn}, cueing completion.")
-                    self.cues.append({'cueKin': 'rctComplete', 'pre': self.pre, 'sn': self.sn})
-                    return True
-                yield tock
-            yield tock
 
 class DipSender(doing.Doer):
     """
-    Sends the delegated inception event to the delegator.
-    """
-    def __init__(self, hab: Hab, sender: str, cues: Deck, postman: Poster):
-        self.hab = hab
-        self.sender = sender
-        self.cues = cues
-        self.postman = postman
-        super(DipSender, self).__init__()
-
-    def sendDip(self):
-        yield from self.postman.sendEventToDelegator(
-            hab=self.hab,
-            sender=self.sender,
-            fn=self.hab.kever.sn)
-
-    def recur(self, tock=0.0, **opts):
-        while True:
-            while self.cues:
-                cue = self.cues.popleft()
-                cueKin = cue["kin"]
-                if cueKin == "rctComplete":
-                    print(f"Sending delegated inception event for {self.hab.pre} to delegator...")
-                    yield from self.sendDip()
-                    self.cues.append({'kin': 'dipSent', 'pre': self.hab.pre})
-                    return True
-                yield tock
-            yield tock
-
-class DipCompleter(doing.Doer):
-    """
-    Completes the delegated inception process by waiting for delegation approval.
+    Uses Anchorer to create and send the "dip" event and waits for delegation approval.
     """
     def __init__(self, anchorer: Anchorer, hab: Hab, cues: Deck):
         self.anchorer = anchorer
         self.hab = hab
         self.cues = cues
-        super(DipCompleter, self).__init__()
+        super(DipSender, self).__init__()
 
-    def recur(self, tock=0.0, **opts):
+    def start_delegation_and_wait(self):
+        """
+        Creates the delegation, sends it to the delegator using Anchorer, and
+        publishes delComplete after delegation approval.
+        """
         self.anchorer.delegation(pre=self.hab.pre, sn=0)
         print(f"Waiting for delegation approval for {self.hab.kever.prefixer.qb64}...")
         while not self.anchorer.complete(self.hab.kever.prefixer, Seqner(sn=self.hab.kever.sn)):
             yield self.tock
         print(f"Delegation approved for {self.hab.kever.prefixer.qb64}, cueing completion.")
         self.cues.append({'kin': 'delComplete', 'pre': self.hab.pre})
+
+    def recur(self, tock=0.0, **opts):
+        yield from self.start_delegation_and_wait()
         return True
 
+class ReceiptWaiter(doing.Doer):
+    """
+    Waits for a receiptor to finish receipting and then publishes a receipt completion cue.
+    """
+    def __init__(self, pre: str, sn: int, cues: decking.Deck, witReceiptor: WitnessReceiptor):
+        self.pre = pre
+        self.sn = sn
+        self.cues = cues
+        self.witReceiptor = witReceiptor
+        super(ReceiptWaiter, self).__init__()
 
+    def waitOnReceipts(self):
+        """
+        Uses Receiptor or WitnessReceiptor to propagate receipts to witnesses.
+        Publishes rctComplete.
+        """
+        self.witReceiptor.msgs.append(dict(pre=self.pre))
+        while not self.witReceiptor.cues:
+            _ = yield self.tock
+        print(f"Receipts obtained for {self.pre} at sn {self.sn}, cueing completion.")
+        self.cues.append({'kin': 'rctComplete', 'pre': self.pre, 'sn': self.sn})
+
+    def recur(self, tock=0.0, **opts):
+        """Consumes rctWait cue and waits on receipts."""
+        while True:
+            while self.cues:
+                cue = self.cues.popleft()
+                cueKin = cue["kin"]
+                if cueKin == "rctWait":
+                    yield from self.waitOnReceipts()
+                    return True
+                else:
+                    self.cues.append(cue)
+                yield tock
+            yield tock
+
+class DipPublisher(doing.Doer):
+    """
+    Sends the delegated inception event to the delegator.
+    """
+    def __init__(self, hab: Hab, proxy: Hab, cues: Deck, postman: Poster):
+        self.hab = hab
+        self.sender = proxy if proxy is not None else hab
+        self.cues = cues
+        self.postman = postman
+        super(DipPublisher, self).__init__()
+
+    def sendDip(self):
+        """Publishes dipSent after sending the "dip" to the delegator."""
+        print(f"Sending delegated inception event for {self.hab.pre} to delegator...")
+        yield from self.postman.sendEventToDelegator(
+            sender=self.sender,
+            hab=self.hab,
+            fn=self.hab.kever.sn)
+        self.cues.append({'kin': 'dipSent', 'pre': self.hab.pre})
+
+    def recur(self, tock=0.0, **opts):
+        """Consumes dipPublish and sends the delegated inception event."""
+        while True:
+            while self.cues:
+                cue = self.cues.popleft()
+                cueKin = cue["kin"]
+                if cueKin == "dipPublish":
+                    yield from self.sendDip()
+                    return True
+                else:
+                    self.cues.append(cue)
+                yield tock
+            yield tock
+
+
+class DipSealer(doing.DoDoer):
+    """
+    Equivalent of `kli delegate confirm` for single-sig delegation approval in tests.
+    Handles the delegation approval lifecycle for single-sig delegators approving single-sig delegation requests.
+    Assumes all delegation requests are to be approved automatically.
+
+    TODO add 2FA witness support (auths)
+    """
+    def __init__(self, hby:Habery, hab: Hab, witRcptrDoer: WitnessReceiptor, interact: bool = True):
+        self.hby = hby
+        self.hab = hab
+        self.interact = interact
+        self.cues = decking.Deck()
+
+        # TODO add group delegation support
+        # Counselor (group only)
+        # Multiplexor (group only)
+
+        # Doers - async tasks
+        self.witInquisitor = WitnessInquisitor(hby=self.hby)
+        self.witRcptrDoer = witRcptrDoer
+        self.approver = DelegableApprover(hby=hby, hab=hab, interact=interact, witRcptr=witRcptrDoer, witq=self.witInquisitor, cues=self.cues)
+        self.toRemove: List[Doer] = [self.witInquisitor, self.approver]
+
+        super(DipSealer, self).__init__(doers=[self.witInquisitor, self.approver])
+
+    def recur(self, tyme, deeds=None):
+        while self.cues:
+            cue = self.cues.popleft()
+            kin = cue.get("kin", "")
+            if kin == "approvalComplete":
+                print(f"Delegation approval process complete for {cue.get('pre')}.")
+                self.remove(self.toRemove)  # remove any remaining doers
+                return True  # done
+            else:
+                self.cues.append(cue)
+            break  # not done yet
+        super(DipSealer, self).recur(tyme, deeds=deeds)  # plumbing call to DoDoer superclass - required
+
+    def delegablesEscrowed(self):
+        return [(pre, sn, edig) for (pre, sn), edig in self.hby.db.delegables.getItemIter()]
+
+class DelegableApprover(Doer):
+    """Checks the delegables escrow and auto-approves them, cueing up either the receipt process or event confirmation."""
+    def __init__(self, hby: Habery, hab: Hab, interact: bool, witRcptr: WitnessReceiptor, witq: WitnessInquisitor, cues: Deck):
+        self.hby = hby
+        self.hab = hab
+        self.interact = interact
+        self.witRcptr = witRcptr
+        self.witq = witq
+        self.cues = cues
+        super(DelegableApprover, self).__init__()
+
+    def delegablesEscrowed(self):
+        return [(pre, sn, edig) for (pre, sn), edig in self.hby.db.delegables.getItemIter()]
+
+    def recur(self, tock=0.0, **opts):
+        self.tock = tock
+        _ = (yield self.tock)
+
+        while True:
+            dlgs = self.delegablesEscrowed()
+            if len(dlgs) == 0:
+                yield self.tock  # no delegables to process - task is not done and should run forever
+            for pre, sn, edig in dlgs:
+                dgkey = dbing.dgKey(pre, edig)
+                eraw = self.hby.db.getEvt(dgkey)
+                if eraw is None:
+                    continue
+                eserder = serdering.SerderKERI(raw=bytes(eraw))  # escrowed event
+
+                ilk = eserder.sad["t"]
+                if ilk in (coring.Ilks.dip,):
+                    delpre = eserder.sad["di"]
+                elif ilk in (coring.Ilks.drt,):
+                    dkever = self.hby.kevers[eserder.pre]
+                    delpre = dkever.delpre
+                else:
+                    continue
+
+                if delpre not in self.hby.prefixes:  # I am the delegator
+                    raise kering.KeriError(f"Delegator {delpre} not found in Habery.")
+                hab = self.hby.habs[delpre]
+
+                if isinstance(hab, GroupHab):
+                    raise kering.ConfigurationError("Group delegation not supported in DipSealer.")
+
+                cur = hab.kever.sner.num
+                anchor = dict(i=eserder.ked['i'], s=eserder.snh, d=eserder.said)
+                if self.interact:
+                    hab.interact(data=[anchor])
+                else:
+                    hab.rotate(data=[anchor])
+
+                # WitnessReceiptor is handled by the outer test context
+                if hab.kever.wits:
+                    witMsg = dict(pre=hab.pre, sn=cur+1)
+                    self.witRcptr.msgs.append({'kin': 'eventToWitness', 'pre': hab.pre, 'sn': cur+1, 'witMsg': witMsg})
+                    while not self.witRcptr.cues:
+                        yield self.tock
+                print(f'Delegagtor Prefix {hab.pre}')
+                print(f'\tDelegate {ilk} event {eserder.pre} Anchored at Seq. No. {hab.kever.sner.num}')
+
+                # wait for confirmation of fully commited event
+                if eserder.pre in self.hby.kevers:
+                    self.witq.query(src=hab.pre, pre=eserder.pre, sn=eserder.sn)
+                    while eserder.sn < self.hby.kevers[eserder.pre].sn:
+                        yield self.tock
+                else:  # It should be an inception event then...
+                    wits = [werfer.qb64 for werfer in eserder.berfers]
+                    self.witq.query(src=hab.pre, pre=eserder.pre, sn=eserder.sn, wits=wits)
+                    while eserder.pre not in self.hby.kevers:
+                        yield self.tock
+
+                print(f"Delegate {ilk} event {eserder.pre} committed.")
+
+                self.hby.db.delegables.rem(keys=(pre, sn), val=edig)
+                self.cues.append({'kin': 'approvalComplete', 'pre': eserder.ked['i']})
+                return True

--- a/uv.lock
+++ b/uv.lock
@@ -177,8 +177,8 @@ wheels = [
 ]
 
 [[package]]
-name = "dws"
-version = "0.3.1"
+name = "did-webs-resolver"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "falcon" },
@@ -198,11 +198,11 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "falcon", specifier = ">=3.1.3" },
-    { name = "keri", specifier = "==1.2.6" },
+    { name = "falcon", specifier = ">=4.0.2" },
+    { name = "keri", specifier = "==1.2.7" },
     { name = "multicommand", specifier = ">=1.0.0" },
-    { name = "requests", specifier = ">=2.28" },
-    { name = "viking", git = "https://github.com/GLEIF-IT/viking" },
+    { name = "requests", specifier = ">=2.32.5" },
+    { name = "viking", git = "https://github.com/GLEIF-IT/viking.git?rev=350745c33322a939ce307a87a1205b0ebaf4e491" },
 ]
 
 [package.metadata.requires-dev]
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "keri"
-version = "1.2.6"
+version = "1.2.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apispec" },
@@ -336,7 +336,7 @@ dependencies = [
     { name = "qrcode" },
     { name = "semver" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/12/3e/4211cd4ee570ccecedbc5f2e4b3074d5d42751fcdb9fde56853a0be4429a/keri-1.2.6.tar.gz", hash = "sha256:15a00b4d3014795a817e05e39495629894eb086c2d65647b275adbce42c116b0", size = 467527, upload-time = "2025-04-14T22:35:20.126Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/3c/fd7627dc9fb013ab2321213595bd02837533fdca856a7f75de7f9d233b21/keri-1.2.7.tar.gz", hash = "sha256:9e2687df544b2bc07ec2d63fa2fe906e8e8ab20bd5b788279da35724e443a223", size = 467791, upload-time = "2025-09-11T13:48:28.728Z" }
 
 [[package]]
 name = "lmdb"
@@ -558,7 +558,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.3"
+version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -566,9 +566,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760", size = 131218, upload-time = "2024-05-29T15:37:49.536Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6", size = 64928, upload-time = "2024-05-29T15:37:47.027Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
 ]
 
 [[package]]
@@ -621,8 +621,8 @@ wheels = [
 
 [[package]]
 name = "viking"
-version = "0.1.0"
-source = { git = "https://github.com/GLEIF-IT/viking#31c89d4d7cf741bc6f13a74761ae13d5f56649aa" }
+version = "0.1.1"
+source = { git = "https://github.com/GLEIF-IT/viking.git?rev=350745c33322a939ce307a87a1205b0ebaf4e491#350745c33322a939ce307a87a1205b0ebaf4e491" }
 dependencies = [
     { name = "keri" },
 ]


### PR DESCRIPTION
### did:webs resolver

This adds a delegation `service` section to the DID document of type `DelegatorOOBI with an OOBI for the delegator where the `id` property is the digest of the anchoring seal in the delegator KEL's interaction event that is the delegation approval.

```jsonc
{
  "service": [{
    "id":"EDEvmKvGFjuip-J5dDw7sbVHxXA22s-pBO764CivsFt4", // SAID of anchor block in delegator KEL
    "type": "DelegatorOOBI", 
    "serviceEndpoint": "http://keria:3902/oobi/..." // OOBI for delegator
  }]
}
```

### did:keri support 

I added support to the did:keri resolver as well to support resolving did:keri DIDs where the AID in the did:keri DID is a delegate. This required adding a while loop check of `aid` being in `hby.kevers` and a `hby.kvy.processEscrows()` which causes the delegate KEL processing to wait until the delegator's KEL and the anchoring delegation approval interaction event is processed. This wait is needed because the Kevery escrow processor only finds the authorizing event seal (AES) when processing the delegator's interaction event where the delegation approval seal is located. This means the delegate's `dip` event won't come out of escrow, and thus will not be in `hby.kevers`, until the delegator's KEL up to the point of the approval is fully processed, thus the inclusion of escrow processing and the additional condition in the while loop for did:keri processing.

### test code added

- `test_resolving.py`: I added a lot of test code in test_resolving to make the main test workflow be to use a delegated identifier.
- `keri_api.py`: 
    - helpers I added a bunch of helpers to make testing easier including OOBI generation, resolving a witness OOBI, and checking for delegable items.
    - Doers: I added the equivalent of a single sig form of `kli incept` with `--delpre` specified and `kli delegate confirm` that auto-approves delegations in order to easily test the delegation workflow from an integration test standpoint. This is the Dipper (delegate side) and DipSealer (delegator side). This is only single sig for now, though multisig support could be straightforwardly added.

### Other changes

- A changelog was added.
- The package name was changed to did-webs-resolver so this could be published to PyPi, which it now is.